### PR TITLE
Add Returns already submitted page

### DIFF
--- a/app/controllers/ReturnsAlreadySubmittedController.scala
+++ b/app/controllers/ReturnsAlreadySubmittedController.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.actions._
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.ReturnsAlreadySubmittedView
+
+import javax.inject.Inject
+
+class ReturnsAlreadySubmittedController @Inject() (
+  override val messagesApi: MessagesApi,
+  identify: IdentifierAction,
+  val controllerComponents: MessagesControllerComponents,
+  returnsAlreadySubmittedView: ReturnsAlreadySubmittedView
+) extends FrontendBaseController
+    with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = identify() { implicit request =>
+    Ok(returnsAlreadySubmittedView())
+  }
+}

--- a/app/controllers/ReturnsCompleteController.scala
+++ b/app/controllers/ReturnsCompleteController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,17 @@ package controllers
 import connectors.DSTConnector
 import controllers.actions._
 import models.PeriodKey
+import pages.ReturnsAlreadySubmittedPage
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import play.twirl.api.Html
+import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.CYAHelper
 import views.html.{PrintableCheckYourAnswersView, ReturnsCompleteView}
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class ReturnsCompleteController @Inject() (
   override val messagesApi: MessagesApi,
@@ -38,7 +40,8 @@ class ReturnsCompleteController @Inject() (
   cyaHelper: CYAHelper,
   val controllerComponents: MessagesControllerComponents,
   view: ReturnsCompleteView,
-  printableCyaView: PrintableCheckYourAnswersView
+  printableCyaView: PrintableCheckYourAnswersView,
+  sessionRepository: SessionRepository
 )(implicit ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
@@ -63,6 +66,8 @@ class ReturnsCompleteController @Inject() (
 
       for {
         outstandingPeriod <- dstConnector.lookupOutstandingReturns()
+        updatedAnswers    <- Future.fromTry(request.userAnswers.set(ReturnsAlreadySubmittedPage, true))
+        _                 <- sessionRepository.set(updatedAnswers)
       } yield Ok(
         view(
           companyName,

--- a/app/pages/ReturnsAlreadySubmittedPage.scala
+++ b/app/pages/ReturnsAlreadySubmittedPage.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import play.api.libs.json.JsPath
+
+case object ReturnsAlreadySubmittedPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "returnsAlreadySubmitted"
+}

--- a/app/views/ReturnsAlreadySubmittedView.scala.html
+++ b/app/views/ReturnsAlreadySubmittedView.scala.html
@@ -1,0 +1,37 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukButton: GovukButton
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = titleNoForm(messages("returns-already-submitted.title"))) {
+
+    @formHelper(action = routes.ReturnsDashboardController.onPageLoad) {
+
+        <h1 class="govuk-heading-xl">@messages("returns-already-submitted.heading")</h1>
+
+        <p class="govuk-body">@messages("returns-already-submitted.p1")</p>
+
+        @govukButton(
+            ButtonViewModel(messages("returns-already-submitted.button"))
+        )
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -120,6 +120,8 @@ POST       /:periodKey/edit/repayment                                      contr
 
 GET        /:periodKey/returns/complete                                    controllers.ReturnsCompleteController.onPageLoad(periodKey: PeriodKey)
 
+GET        /returns/already-complete                                       controllers.ReturnsAlreadySubmittedController.onPageLoad
+
 GET        /:periodKey/report-online-marketplace-operating-margin          controllers.ReportOnlineMarketplaceOperatingMarginController.onPageLoad(periodKey: PeriodKey, mode: Mode = NormalMode)
 POST       /:periodKey/report-online-marketplace-operating-margin          controllers.ReportOnlineMarketplaceOperatingMarginController.onSubmit(periodKey: PeriodKey, mode: Mode = NormalMode)
 GET        /:periodKey/edit/report-online-marketplace-operating-margin     controllers.ReportOnlineMarketplaceOperatingMarginController.onPageLoad(periodKey: PeriodKey, mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -338,6 +338,12 @@ returnsComplete.what-you-do-next.p1 = Your next return will be for {0} to {1}.
 returnsComplete.what-you-do-next.p2 = You must pay any Digital Services Tax you owe for your next return period by {0} and submit a return by {1}.
 returnsComplete.index = Go to your Digital Services Tax details
 returnsComplete.before-you-go= Before you go
+
+returns-already-submitted.title = Returns Submitted
+returns-already-submitted.heading = Returns Submitted
+returns-already-submitted.p1 = Your session has been cleared because you submitted your returns.
+returns-already-submitted.button = Start Again
+
 common.feedback.p1 = Your feedback helps us make our service better.
 common.feedback.survey = Take our survey
 common.feedback.survey.p1 = to share your feedback on this service. It takes about 1 minute to complete.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.8.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.12.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.3.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"            % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % hmrcMongoVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,12 +2,12 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.19.0"
+  private val bootstrapVersion = "10.1.0"
   private val hmrcMongoVersion = "2.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.12.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.15.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.3.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"            % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % hmrcMongoVersion,

--- a/test/controllers/ReturnsAlreadySubmittedControllerSpec.scala
+++ b/test/controllers/ReturnsAlreadySubmittedControllerSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.ReturnsAlreadySubmittedView
+
+class ReturnsAlreadySubmittedControllerSpec extends SpecBase {
+
+  "ReturnsAlreadySubmitted Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.ReturnsAlreadySubmittedController.onPageLoad.url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[ReturnsAlreadySubmittedView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view()(request, messages(application)).toString
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add Returns already submitted page to prevent going back to check your answers after already submitting, and resubmitting the same returns